### PR TITLE
Add repo field so npm stops complaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "directories": {
     "test": "test"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/btford/passive-voice.git"
+  },
   "scripts": {
     "test": "./node_modules/.bin/jasmine-node test"
   },


### PR DESCRIPTION
npm complains when you install write-good as this repo does not have a repo field.
